### PR TITLE
sha256のテストに使っているcryptoがテストではNotFoundになるのでそこ以外テスト追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,15 @@
 {
-    "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
-    },
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.renderWhitespace": "boundary",
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "editor.guides.bracketPairs": true,
+  "prettier.trailingComma": "none",
+  "prettier.semi": false,
+  "prettier.singleQuote": true
+}

--- a/src/components/Develop.vue
+++ b/src/components/Develop.vue
@@ -212,7 +212,7 @@ const randomlength = ref(10)
 const randomvalue = ref('')
 const randomerror = ref('')
 
-// ウォッチャーの定義
+// functions
 const stringToHex = (str) => {
   return Array.from(new TextEncoder().encode(str))
     .map((b) => b.toString(16).padStart(2, '0'))
@@ -248,108 +248,6 @@ const base64ToString = (base64) => {
   }
 }
 
-watch(b64plane, (newValue) => {
-  try {
-    const b64hexValue = stringToHex(newValue)
-    const b64strValue = stringToBase64(newValue)
-    const b64urlstrValue = b64strValue
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=/g, '')
-    const invalidHexRegex = /^(efbfbd)+$/
-    if (invalidHexRegex.test(b64hexValue)) return
-    b64hex.value = b64hexValue
-    b64str.value = b64strValue
-    b64urlstr.value = b64urlstrValue
-  } catch (err) {
-    b64error.value = UNKNOWN_ERROR + err.message
-  }
-})
-
-watch(b64hex, (newValue) => {
-  try {
-    const hexRegex = /^([0-9a-f][0-9a-f])+$/
-    if (!hexRegex.test(newValue)) {
-      b64plane.value = ''
-      b64str.value = ''
-      b64error.value = 'その値はBase64エンコードされた16進数ではないです。'
-      return
-    }
-    const b64planeValue = hexToString(newValue)
-    b64plane.value = b64planeValue
-    b64error.value = ''
-  } catch (err) {
-    b64error.value = UNKNOWN_ERROR + err.message
-  }
-})
-
-watch(b64str, (newValue) => {
-  try {
-    b64plane.value = base64ToString(newValue)
-    b64error.value = ''
-  } catch (err) {
-    b64error.value = UNKNOWN_ERROR + err.message
-  }
-})
-
-watch(b64urlstr, (newValue) => {
-  try {
-    const base64 = newValue.replace(/-/g, '+').replace(/_/g, '/')
-    b64plane.value = base64ToString(base64)
-    b64error.value = ''
-  } catch (err) {
-    b64error.value = UNKNOWN_ERROR + err.message
-  }
-})
-
-watch(urldecode, (newValue) => {
-  try {
-    const urlencodeValue = encodeURIComponent(newValue)
-    urlencode.value = urlencodeValue
-    urlerror.value = ''
-  } catch (err) {
-    urlerror.value = UNKNOWN_ERROR + err.message
-  }
-})
-
-watch(urlencode, (newValue) => {
-  try {
-    const urldecodeValue = decodeURIComponent(newValue)
-    urldecode.value = urldecodeValue
-    urlerror.value = ''
-  } catch (err) {
-    if (err.name === 'URIError') {
-      urlerror.value = 'その値はURLデコードできないです。'
-    } else {
-      urlerror.value = UNKNOWN_ERROR + err.message
-    }
-  }
-})
-
-watch(hashplain, (newValue) => {
-  try {
-    hasherror.value = ''
-    crypto.subtle
-      .digest('SHA-256', new TextEncoder().encode(newValue))
-      .then((result) => {
-        hashsha256.value = ''
-        new Uint8Array(result).forEach((bit) => {
-          hashsha256.value += ('00' + bit.toString(16)).slice(-2)
-        })
-        hashsha256b64.value = btoa(
-          String.fromCharCode(...new Uint8Array(result))
-        )
-        hashsha256b64url.value = hashsha256b64.value
-          .replace(/\+/g, '-')
-          .replace(/\//g, '_')
-          .replace(/=/g, '')
-      })
-  } catch (err) {
-    hasherror.value = UNKNOWN_ERROR + err.message
-  }
-})
-
-// メソッドの定義
 const randomgenerate = () => {
   const array = new Uint8Array(randomlength.value)
   crypto.getRandomValues(array)
@@ -359,6 +257,127 @@ const randomgenerate = () => {
     randomvalue.value += randomseed.value[index]
   }
 }
+
+// watchers
+watch(
+  () => b64plane.value, (newValue) => {
+    try {
+      if (!newValue) {
+        b64hex.value = ''
+        b64str.value = ''
+        return
+      }
+      const hexValue = stringToHex(newValue)
+      const strValue = stringToBase64(newValue)
+      const urlstrValue = strValue
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '')
+      const invalidHexRegex = /^(efbfbd)+$/
+      if (invalidHexRegex.test(hexValue)) return
+      b64hex.value = hexValue
+      b64str.value = strValue
+      b64urlstr.value = urlstrValue
+    } catch (err) {
+      b64error.value = UNKNOWN_ERROR + err.message
+    }
+  }
+)
+
+watch(
+  () => b64hex.value, (newValue) => {
+    try {
+      const hexRegex = /^([0-9a-f][0-9a-f])+$/
+      if (!hexRegex.test(newValue)) {
+        b64plane.value = ''
+        b64str.value = ''
+        b64error.value = 'その値はBase64エンコードされた16進数ではないです。'
+        return
+      }
+      const b64planeValue = hexToString(newValue)
+      b64plane.value = b64planeValue
+      b64error.value = ''
+    } catch (err) {
+      b64error.value = UNKNOWN_ERROR + err.message
+    }
+  }
+)
+
+watch(
+  () => b64str.value, (newValue) => {
+    try {
+      b64plane.value = base64ToString(newValue)
+      b64error.value = ''
+    } catch (err) {
+      b64error.value = UNKNOWN_ERROR + err.message
+    }
+  }
+)
+
+watch(
+  () => b64urlstr.value, (newValue) => {
+    try {
+      const base64 = newValue.replace(/-/g, '+').replace(/_/g, '/')
+      b64plane.value = base64ToString(base64)
+      b64error.value = ''
+    } catch (err) {
+      b64error.value = UNKNOWN_ERROR + err.message
+    }
+  }
+)
+
+watch(
+  () => urldecode.value, (newValue) => {
+    try {
+      const urlencodeValue = encodeURIComponent(newValue)
+      urlencode.value = urlencodeValue
+      urlerror.value = ''
+    } catch (err) {
+      urlerror.value = UNKNOWN_ERROR + err.message
+    }
+  }
+)
+
+watch(
+  () => urlencode.value, (newValue) => {
+    try {
+      const urldecodeValue = decodeURIComponent(newValue)
+      urldecode.value = urldecodeValue
+      urlerror.value = ''
+    } catch (err) {
+      if (err.name === 'URIError') {
+        urlerror.value = 'その値はURLデコードできないです。'
+      } else {
+        urlerror.value = UNKNOWN_ERROR + err.message
+      }
+    }
+  }
+)
+
+watch(
+  () => hashplain.value, (newValue) => {
+    try {
+      hasherror.value = ''
+      crypto.subtle
+        .digest('SHA-256', new TextEncoder().encode(newValue))
+        .then((result) => {
+          hashsha256.value = ''
+          new Uint8Array(result).forEach((bit) => {
+            hashsha256.value += ('00' + bit.toString(16)).slice(-2)
+          })
+          hashsha256b64.value = btoa(
+            String.fromCharCode(...new Uint8Array(result))
+          )
+          hashsha256b64url.value = hashsha256b64.value
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=/g, '')
+        })
+    } catch (err) {
+      hasherror.value = UNKNOWN_ERROR + err.message
+    }
+  }
+)
 </script>
 
 <style scoped></style>

--- a/tests/unit/Develop.spec.js
+++ b/tests/unit/Develop.spec.js
@@ -23,7 +23,7 @@ describe('Develop.vue', () => {
     expect(wrapper.vm.stringToHex('test')).toBe('74657374')
   })
 
-  it('base64 deencode (base64hex => string)', () => {
+  it('base64 dencode (base64hex => string)', () => {
     expect(wrapper.vm.hexToString('74657374')).toBe('test')
   })
 
@@ -31,7 +31,7 @@ describe('Develop.vue', () => {
     expect(wrapper.vm.stringToBase64('test')).toBe('dGVzdA==')
   })
 
-  it('base64 encode (base64str => plain)', () => {
+  it('base64 decode (base64str => plain)', () => {
     expect(wrapper.vm.base64ToString('dGVzdA==')).toBe('test')
     expect(wrapper.vm.base64ToString('dGVzdA')).toBe('test')
   })

--- a/tests/unit/Develop.spec.js
+++ b/tests/unit/Develop.spec.js
@@ -1,27 +1,184 @@
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import Develop from '@/components/Develop.vue'
+import { TextEncoder, TextDecoder } from 'util'
+
+global.TextEncoder = TextEncoder
+global.TextDecoder = TextDecoder
 
 describe('Develop.vue', () => {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(async() => {
     wrapper = mount(Develop)
+    await nextTick()
   })
 
   afterEach(() => {
     wrapper.unmount()
   })
 
+  // functions
+  it('base64 encode (plain => base64hex)', () => {
+    expect(wrapper.vm.stringToHex('test')).toBe('74657374')
+  })
+
+  it('base64 deencode (base64hex => string)', () => {
+    expect(wrapper.vm.hexToString('74657374')).toBe('test')
+  })
+
+  it('base64 encode (plain => base64str)', () => {
+    expect(wrapper.vm.stringToBase64('test')).toBe('dGVzdA==')
+  })
+
+  it('base64 encode (base64str => plain)', () => {
+    expect(wrapper.vm.base64ToString('dGVzdA==')).toBe('test')
+    expect(wrapper.vm.base64ToString('dGVzdA')).toBe('test')
+  })
+
+  it('random generator', async() => {
+    const lengthInput = wrapper.find('input[id="randomlength"]')
+    await lengthInput.setValue("8")
+    const seedInput = wrapper.find('input[id="randomseed"]')
+    await seedInput.setValue("abc")
+    wrapper.vm.randomgenerate()
+
+    expect(wrapper.vm.randomvalue).toMatch(/[a-c]{8}/)
+  })
+
+  // watchers
+  it('base64 plane', async () => {
+    expect(wrapper.vm.b64plane).toBe('')
+    expect(wrapper.vm.b64hex).toBe('')
+    expect(wrapper.vm.b64str).toBe('')
+    expect(wrapper.vm.b64urlstr).toBe('')
+
+    const input = wrapper.find('input[id="b64plane"]')
+    await input.setValue('test')
+
+    expect(wrapper.vm.b64hex).toBe('74657374')
+    expect(wrapper.vm.b64str).toBe('dGVzdA==')
+    expect(wrapper.vm.b64urlstr).toBe('dGVzdA')
+
+    // DOM の更新も確認
+    const hexInput = wrapper.find('input[id="b64hex"]')
+    const strInput = wrapper.find('input[id="b64str"]')
+    const urlstrInput = wrapper.find('input[id="b64urlstr"]')
+
+    expect(hexInput.element.value).toBe('74657374')
+    expect(strInput.element.value).toBe('dGVzdA==')
+    expect(urlstrInput.element.value).toBe('dGVzdA')
+  })
+
+  it('base64 hex', async () => {
+    expect(wrapper.vm.b64plane).toBe('')
+    expect(wrapper.vm.b64hex).toBe('')
+    expect(wrapper.vm.b64str).toBe('')
+    expect(wrapper.vm.b64urlstr).toBe('')
+
+    const input = wrapper.find('input[id="b64hex"]')
+    await input.setValue('74657374')
+
+    expect(wrapper.vm.b64plane).toBe('test')
+    expect(wrapper.vm.b64str).toBe('dGVzdA==')
+    expect(wrapper.vm.b64urlstr).toBe('dGVzdA')
+
+    // DOM の更新も確認
+    const planeInput = wrapper.find('input[id="b64plane"]')
+    const strInput = wrapper.find('input[id="b64str"]')
+    const urlstrInput = wrapper.find('input[id="b64urlstr"]')
+
+    expect(planeInput.element.value).toBe('test')
+    expect(strInput.element.value).toBe('dGVzdA==')
+    expect(urlstrInput.element.value).toBe('dGVzdA')
+  })
+
+  it('base64 str', async () => {
+    expect(wrapper.vm.b64plane).toBe('')
+    expect(wrapper.vm.b64hex).toBe('')
+    expect(wrapper.vm.b64str).toBe('')
+    expect(wrapper.vm.b64urlstr).toBe('')
+
+    const input = wrapper.find('input[id="b64str"]')
+    await input.setValue('dGVzdA==')
+
+    expect(wrapper.vm.b64plane).toBe('test')
+    expect(wrapper.vm.b64hex).toBe('74657374')
+    expect(wrapper.vm.b64urlstr).toBe('dGVzdA')
+
+    // DOM の更新も確認
+    const planeInput = wrapper.find('input[id="b64plane"]')
+    const hexInput = wrapper.find('input[id="b64hex"]')
+    const urlstrInput = wrapper.find('input[id="b64urlstr"]')
+
+    expect(planeInput.element.value).toBe('test')
+    expect(hexInput.element.value).toBe('74657374')
+    expect(urlstrInput.element.value).toBe('dGVzdA')
+  })
+
+  it('base64 urlstr', async () => {
+    expect(wrapper.vm.b64plane).toBe('')
+    expect(wrapper.vm.b64hex).toBe('')
+    expect(wrapper.vm.b64str).toBe('')
+    expect(wrapper.vm.b64urlstr).toBe('')
+
+    const input = wrapper.find('input[id="b64urlstr"]')
+    await input.setValue('dGVzdA')
+
+    expect(wrapper.vm.b64plane).toBe('test')
+    expect(wrapper.vm.b64hex).toBe('74657374')
+    expect(wrapper.vm.b64str).toBe('dGVzdA==')
+
+    // DOM の更新も確認
+    const planeInput = wrapper.find('input[id="b64plane"]')
+    const hexInput = wrapper.find('input[id="b64hex"]')
+    const strInput = wrapper.find('input[id="b64str"]')
+
+    expect(planeInput.element.value).toBe('test')
+    expect(hexInput.element.value).toBe('74657374')
+    expect(strInput.element.value).toBe('dGVzdA==')
+  })
+
+  it('url encode', async () => {
+    expect(wrapper.vm.urldecode).toBe('')
+    expect(wrapper.vm.urlencode).toBe('')
+
+    const input = wrapper.find('input[id="urldecode"]')
+    await input.setValue('hoge fuga')
+
+    expect(wrapper.vm.urlencode).toBe('hoge%20fuga')
+
+    // DOM の更新も確認
+    const urlencodeInput = wrapper.find('input[id="urlencode"]')
+
+    expect(urlencodeInput.element.value).toBe('hoge%20fuga')
+  })
+
+  it('url decode', async () => {
+    expect(wrapper.vm.urldecode).toBe('')
+    expect(wrapper.vm.urlencode).toBe('')
+
+    const input = wrapper.find('input[id="urlencode"]')
+    await input.setValue('hoge%20fuga')
+
+    expect(wrapper.vm.urldecode).toBe('hoge fuga')
+
+    // DOM の更新も確認
+    const urldecodeInput = wrapper.find('input[id="urldecode"]')
+
+    expect(urldecodeInput.element.value).toBe('hoge fuga')
+  })
+
   it('generates random string', async () => {
     const lengthInput = wrapper.find('input[id="randomlength"]')
     const generateButton = wrapper.find('input[id="randomgenerateButton"]')
-    
+
     expect(lengthInput.exists()).toBe(true)
     expect(generateButton.exists()).toBe(true)
-    
+
     await lengthInput.setValue('10')
     await generateButton.trigger('click')
-    
+
     const randomValue = wrapper.vm.randomvalue
     expect(randomValue).toHaveLength(10)
   })


### PR DESCRIPTION
# 起票者コメント
## カバレッジ

```
$ npm run test:coverage

> uji52.com@2.0.0 test:coverage
> jest --coverage

 PASS  tests/unit/Develop.spec.js
 PASS  tests/unit/Landing.spec.js
 PASS  tests/unit/ReleaseNote.spec.js
------------------|---------|----------|---------|---------|----------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------|---------|----------|---------|---------|----------------------
All files         |   82.56 |     81.6 |   67.85 |   90.81 |
 components       |    82.4 |     81.6 |   67.85 |   90.72 |
  Develop.vue     |    72.3 |    75.86 |   57.89 |   85.18 | 12-13,16,556-583,621
  Feedback.vue    |   83.33 |        0 |       0 |   83.33 | 12
  Landing.vue     |     100 |      100 |     100 |     100 |
  ReleaseNote.vue |     100 |      100 |     100 |     100 |
 data             |     100 |      100 |     100 |     100 |
  releases.js     |     100 |      100 |     100 |     100 |
------------------|---------|----------|---------|---------|----------------------

Test Suites: 3 passed, 3 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        0.909 s, estimated 1 s
```

## その他

# AIパート


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザー向けにランダム文字列生成機能を追加し、より多様なデータ操作が可能になりました。
- **リファクタリング**
  - エンコード／デコード処理の内部ロジックを改善し、操作のレスポンスと信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->